### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lxml
+unidecode


### PR DESCRIPTION
module unidecode is required too (not installeb by default by Python 2.7.5 amd64)
