### PR TITLE
fix empty orgid tag bug

### DIFF
--- a/sepacbi/entity.py
+++ b/sepacbi/entity.py
@@ -136,8 +136,11 @@ class IdHolder(AttributeCarrier):
         if hasattr(self, 'code'):
             orgid.append(emit_id_tag(self.code, None))
 
-        if not orgid:
+        if len(orgid) == 0:
             idtag.remove(orgid)
+
+        if len(idtag) == 0:
+            root.remove(idtag)
 
         if not as_initiator and hasattr(self, 'country'):
             etree.SubElement(root, 'CtryOfRes').text = self.country

--- a/sepacbi/entity.py
+++ b/sepacbi/entity.py
@@ -28,6 +28,7 @@ class Address(AttributeCarrier):
     """
     The postal address of an entity.
     """
+
     def __init__(self, *args):
         """
         The argument processing is NOT based on keyword parameters, so we
@@ -134,6 +135,9 @@ class IdHolder(AttributeCarrier):
 
         if hasattr(self, 'code'):
             orgid.append(emit_id_tag(self.code, None))
+
+        if not orgid:
+            idtag.remove(orgid)
 
         if not as_initiator and hasattr(self, 'country'):
             etree.SubElement(root, 'CtryOfRes').text = self.country


### PR DESCRIPTION
If IdHolder have only the "name" parameter when instantiated, the xml had some empty tag. This fix make a check.